### PR TITLE
Weyl electric Simple and Compute tags

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
@@ -84,6 +85,32 @@ struct SpatialChristoffelSecondKindCompute
                                   SpatialIndex<SpatialDim, UpLo::Lo, Frame>,
                                   SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
   using base = SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>;
+};
+
+/// Compute item for spatial Christoffel symbols of the second kind
+/// \f$\Gamma^i_{jk}\f$ computed from the Christoffel symbols of the
+/// first kind and the inverse spatial metric, returned as a
+/// `Variables<tmpl::list<gr::Tags::SpatialChristoffelSecondKind>>`.
+///
+/// Can be retrieved using `gr::Tags::SpatialChristoffelSecondKind`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct SpatialChristoffelSecondKindVarsCompute
+    : ::Tags::Variables<tmpl::list<
+          SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>>>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpatialChristoffelFirstKind<SpatialDim, Frame, DataType>,
+                 InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+  static ::Variables<
+      tmpl::list<SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>>>
+  function(
+      const tnsr::ijj<DataType, SpatialDim, Frame>& christoffel,
+      const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric) {
+    return variables_from_tagged_tuple(
+        tuples::TaggedTuple<
+            SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>>(
+            raise_or_lower_first_index(christoffel, inverse_spatial_metric)));
+  }
 };
 
 /// Compute item for the trace of the spatial Christoffel symbols

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 namespace gr {
 
@@ -29,4 +30,23 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
     const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
         d_christoffel_2nd_kind) noexcept;
 
+namespace Tags {
+/// Compute item for spatial Ricci tensor \f$\R_{ij}\f$
+/// computed from SpatialChristoffelSecondKind and its spatial derivatives.
+///
+/// Can be retrieved using `gr::Tags::RicciTensor`
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct RicciTensorCompute : RicciTensor<SpatialDim, Frame, DataType>,
+                            db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
+      ::Tags::deriv<
+          gr::Tags::SpatialChristoffelSecondKind<SpatialDim, Frame, DataType>,
+          tmpl::size_t<SpatialDim>, Frame>>;
+  static constexpr tnsr::ii<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::Ijj<DataType, SpatialDim, Frame>&,
+      const tnsr::iJkk<DataType, SpatialDim, Frame>&) =
+      &ricci_tensor<SpatialDim, Frame, IndexType::Spatial, DataType>;
+};
+}  // namespace Tags
 } // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -155,6 +155,12 @@ struct TraceExtrinsicCurvature : db::SimpleTag {
   static std::string name() noexcept { return "TraceExtrinsicCurvature"; }
 };
 
+template <size_t Dim, typename Frame, typename DataType>
+struct RicciTensor : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "RicciTensor"; }
+};
+
 /*!
  * \brief The energy density \f$E=t_a t_b T^{ab}\f$, where \f$t_a\f$ denotes the
  * normal to the spatial hypersurface

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -170,6 +170,12 @@ struct EnergyDensity : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "EnergyDensity"; }
 };
+
+template <size_t Dim, typename Frame, typename DataType>
+struct WeylElectric : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "WeylElectric"; }
+};
 }  // namespace Tags
 
 /// The tags for the variables returned by GR analytic solutions.

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
@@ -15,12 +15,13 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> weyl_electric(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_ricci,
     const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
-    const gsl::not_null<tnsr::II<DataType, SpatialDim, Frame>*>
+    const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept {
   tnsr::ii<DataType, SpatialDim, Frame> weyl_electric_part{
-      get_size(get<0, 0>(*inverse_spatial_metric))};
-  weyl_electric(make_not_null(&weyl_electric_part), spatial_ricci,
-                extrinsic_curvature, *inverse_spatial_metric);
+      get_size(get<0, 0>(inverse_spatial_metric))};
+  weyl_electric<SpatialDim, Frame, DataType>(
+      make_not_null(&weyl_electric_part), spatial_ricci,
+      extrinsic_curvature, inverse_spatial_metric);
   return weyl_electric_part;
 }
 
@@ -30,12 +31,12 @@ void weyl_electric(
         weyl_electric_part,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_ricci,
     const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
-    const gsl::not_null<tnsr::II<DataType, SpatialDim, Frame>*>
+    const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept {
   if (UNLIKELY(get_size(get<0, 0>(*weyl_electric_part)) !=
-               get_size(get<0, 0>(*inverse_spatial_metric)))) {
+               get_size(get<0, 0>(inverse_spatial_metric)))) {
     *weyl_electric_part = tnsr::ii<DataType, SpatialDim, Frame>(
-        get_size(get<0, 0>(*inverse_spatial_metric)));
+        get_size(get<0, 0>(inverse_spatial_metric)));
   }
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
@@ -45,10 +46,10 @@ void weyl_electric(
         for (size_t l = 0; l < SpatialDim; ++l) {
           weyl_electric_part->get(i, j) +=
               extrinsic_curvature.get(k, l) *
-                  (inverse_spatial_metric->get(k, l)) *
+                  (inverse_spatial_metric.get(k, l)) *
                   extrinsic_curvature.get(i, j) -
               extrinsic_curvature.get(i, l) *
-                  (inverse_spatial_metric->get(k, l)) *
+                  (inverse_spatial_metric.get(k, l)) *
                   extrinsic_curvature.get(k, j);
         }
       }
@@ -68,7 +69,7 @@ void weyl_electric(
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_ricci,   \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                  \
           extrinsic_curvature,                                              \
-      const gsl::not_null<tnsr::II<DTYPE(data), DIM(data), FRAME(data)>*>   \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
           inverse_spatial_metric) noexcept;                                 \
   template void gr::weyl_electric(                                          \
       const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>   \
@@ -76,7 +77,7 @@ void weyl_electric(
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_ricci,   \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                  \
           extrinsic_curvature,                                              \
-      const gsl::not_null<tnsr::II<DTYPE(data), DIM(data), FRAME(data)>*>   \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
           inverse_spatial_metric) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 #include "Utilities/Gsl.hpp"
 
@@ -32,9 +33,30 @@ tnsr::ii<DataType, SpatialDim, Frame> weyl_electric(
 
 template <size_t SpatialDim, typename Frame, typename DataType>
 void weyl_electric(
-    gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> weyl_electric_part,
+    const gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*>
+        weyl_electric_part,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_ricci,
     const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature,
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
+
+namespace Tags {
+/// Compute item for the electric part of the weyl tensor in vacuum
+/// Computed from the RicciTensor, ExtrinsicCurvature, and InverseSpatialMetric
+///
+/// Can be retrieved using gr::Tags::WeylElectric
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct WeylElectricCompute : WeylElectric<SpatialDim, Frame, DataType>,
+                             db::ComputeTag {
+  static constexpr tnsr::ii<DataType, SpatialDim, Frame> (*function)(
+      const tnsr::ii<DataType, SpatialDim, Frame>&,
+      const tnsr::ii<DataType, SpatialDim, Frame>&,
+      const tnsr::II<DataType, SpatialDim, Frame>&) =
+          &weyl_electric<SpatialDim, Frame, DataType>;
+  using argument_tags = tmpl::list<
+      gr::Tags::RicciTensor<SpatialDim, Frame, DataType>,
+      gr::Tags::ExtrinsicCurvature<SpatialDim, Frame, DataType>,
+      gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataType>>;
+};
+}  // namespace Tags
 }  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
@@ -23,8 +23,7 @@ void test_weyl_electric(const DataType& used_for_size) {
       const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
       const tnsr::II<DataType, SpatialDim, Frame::Inertial>&) =
       &gr::weyl_electric<SpatialDim, Frame::Inertial, DataType>;
-  pypp::check_with_random_values<1>(f, "WeylElectric", "weyl_electric_tensor",
-                                    {{{-1., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(f, "WeylElectric", "weyl_electric_tensor",                                               {{{-1., 1.}}}, used_for_size);
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylElectric.cpp
@@ -23,7 +23,8 @@ void test_weyl_electric(const DataType& used_for_size) {
       const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
       const tnsr::II<DataType, SpatialDim, Frame::Inertial>&) =
       &gr::weyl_electric<SpatialDim, Frame::Inertial, DataType>;
-  pypp::check_with_random_values<1>(f, "WeylElectric", "weyl_electric_tensor",                                               {{{-1., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(f, "WeylElectric", "weyl_electric_tensor",
+                                    {{{-1., 1.}}}, used_for_size);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Adds a Simple and Compute tag for computing the electric part of the weyl tensor in vacuum.

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests and `clang-tidy`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).